### PR TITLE
Normalize stereo width to prevent gain changes

### DIFF
--- a/Source/AdvancedReverbEngine.cpp
+++ b/Source/AdvancedReverbEngine.cpp
@@ -747,8 +747,12 @@ void AdvancedReverbEngine::processStereo(float leftInput, float rightInput, floa
     {
         const float mid  = 0.5f * (wetL + wetR);
         const float side = 0.5f * (wetL - wetR) * width;
-        wetL = mid + side;
-        wetR = mid - side;
+
+        // Prevent width changes from altering perceived loudness
+        const float norm = 1.0f / juce::jmax(1.0f, std::sqrt((width * width + 1.0f) * 0.5f));
+
+        wetL = (mid + side) * norm;
+        wetR = (mid - side) * norm;
     }
 
     // 8.  Optional high-cut on wet path


### PR DESCRIPTION
## Summary
- Normalize stereo width processing in distance engine to keep loudness stable
- Apply same normalization to standalone stereo width routine
- Prevent reverb width control from boosting level beyond unity

## Testing
- `./build.sh` *(fails: cd: JUCE/extras/Projucer/Builds/MacOSX/: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893efaa4f8c832ca832ee17b89ea2b7