### PR TITLE
Implement realistic spatial processing and environment selection

### DIFF
--- a/Source/DistanceProcessor.h
+++ b/Source/DistanceProcessor.h
@@ -3,6 +3,7 @@
 #include <JuceHeader.h>
 #include <limits>
 #include "MySofaHRIR.h"
+#include "EarlyReflectionIR.h"
 
 //==============================================================================
 /**
@@ -15,10 +16,13 @@ class DistanceProcessor
 {
 public:
     //==============================================================================
-    // Environment types - reduced to 4 realistic room types
+    // Environment types
     enum Environment
     {
-        Generic = 0,
+        Room = 0,
+        Studio,
+        Hall,
+        Cave,
         numEnvironments
     };
     
@@ -136,8 +140,8 @@ private:
     
     //==============================================================================
     // Environment and processing state
-    Environment currentEnvironment = Generic;
-    Environment lastEnvironment = Generic;
+    Environment currentEnvironment = Room;
+    Environment lastEnvironment = Room;
     float currentDistance = 0.0f;
     float currentPan = 0.0f;
     float leftPanGain = 0.707f;
@@ -171,10 +175,14 @@ private:
 
     static constexpr float listenerEarHeight = 1.7f; // metres above floor – average ear height when seated/standing
 
+    // Early reflection processor
+    EarlyReflectionIR earlyReflection;
+
     // HRTF binaural convolution
     MySofaHrirDatabase hrirDatabase;
     juce::dsp::Convolution hrtfLeft { juce::dsp::Convolution::NonUniform { 128 } };
     juce::dsp::Convolution hrtfRight{ juce::dsp::Convolution::NonUniform { 128 } };
+    juce::AudioBuffer<float> hrtfTempBuffer;
     float lastAzimuthDeg = 0.0f, lastElevationDeg = 0.0f;
 
     // Cache last geometry state to avoid expensive updates each block

--- a/Source/EarlyReflectionIR.h
+++ b/Source/EarlyReflectionIR.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include <array>
 
 /**
  * Early Reflection Impulse Response Generator
@@ -12,43 +13,84 @@ public:
     EarlyReflectionIR() = default;
     ~EarlyReflectionIR() = default;
 
-    void prepare(double sampleRate, int samplesPerBlock, int numChannels = 2)
+    /**
+     * Prepare internal buffers for processing. The processing block is small so
+     * we preallocate a temporary buffer once and reuse it to avoid dynamic
+     * allocations in the audio thread.
+     */
+    void prepare (double sampleRate, int samplesPerBlock, int numChannelsIn = 2)
     {
         currentSampleRate = sampleRate;
-        this->numChannels = numChannels;
-    }
+        numChannels       = numChannelsIn;
 
-    void loadDirac(int length, double sampleRate)
-    {
-        // Simple dirac impulse for testing
-        // In real implementation would generate proper IR
+        const int maxDelaySamples = static_cast<int> (sampleRate * 0.05); // 50 ms headroom
+        reflectionBuffer.setSize (numChannels, samplesPerBlock + maxDelaySamples);
+        reflectionBuffer.clear();
     }
 
     void reset()
     {
-        // Reset any internal state if needed
+        reflectionBuffer.clear();
     }
 
-    void setRoomDimensions(float width, float height, float length)
+    void setRoomDimensions (float width, float height, float length)
     {
-        roomWidth = width;
+        roomWidth  = width;
         roomHeight = height;
         roomLength = length;
     }
 
-    void process(juce::AudioBuffer<float>& buffer)
+    /**
+     * Add a crude set of first‑order reflections. This is intentionally simple
+     * but provides noticeably more spatial impression than the previous stub.
+     */
+    void process (juce::AudioBuffer<float>& buffer)
     {
-        // Simplified early reflection processing
-        // In a real implementation, this would generate early reflections
-        // based on room dimensions and distance
+        const int numSamples = buffer.getNumSamples();
+        const float c = 343.0f; // speed of sound (m/s)
+
+        reflectionBuffer.clear();
+
+        // Copy dry signal
+        for (int ch = 0; ch < juce::jmin (numChannels, buffer.getNumChannels()); ++ch)
+            reflectionBuffer.copyFrom (ch, 0, buffer, ch, 0, numSamples);
+
+        // Distances to six walls from the source placed at centre
+        const float distX = roomWidth  * 0.5f;
+        const float distY = roomHeight * 0.5f;
+        const float distZ = roomLength * 0.5f;
+
+        const std::array<float,6> delays {
+            distX / c,  // left wall
+            distX / c,  // right wall
+            distY / c,  // floor
+            distY / c,  // ceiling
+            distZ / c,  // front wall
+            distZ / c   // back wall
+        };
+
+        const std::array<float,6> gains { 0.5f, 0.5f, 0.5f, 0.5f, 0.4f, 0.4f };
+
+        for (size_t i = 0; i < delays.size(); ++i)
+        {
+            const int delaySamples = static_cast<int> (delays[i] * currentSampleRate);
+            for (int ch = 0; ch < juce::jmin (numChannels, buffer.getNumChannels()); ++ch)
+                reflectionBuffer.addFrom (ch, delaySamples, buffer, ch, 0, numSamples, gains[i]);
+        }
+
+        // Write back the processed block
+        for (int ch = 0; ch < juce::jmin (numChannels, buffer.getNumChannels()); ++ch)
+            buffer.copyFrom (ch, 0, reflectionBuffer, ch, 0, numSamples);
     }
 
 private:
     double currentSampleRate = 44100.0;
-    float roomWidth = 6.0f;
-    float roomHeight = 3.0f;
-    float roomLength = 8.0f;
-    int numChannels = 2;
+    float  roomWidth  = 6.0f;
+    float  roomHeight = 3.0f;
+    float  roomLength = 8.0f;
+    int    numChannels = 2;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EarlyReflectionIR)
+    juce::AudioBuffer<float> reflectionBuffer;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (EarlyReflectionIR)
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -215,7 +215,8 @@ void SOFARAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::
         distanceProcessor.setSourceHeight(heightPct);
         
         // Process with actual distance in meters (not percentage)
-        distanceProcessor.processBlock(buffer, actualDistance, panning, DistanceProcessor::Generic);
+        auto env = static_cast<DistanceProcessor::Environment> (currentRoomType);
+        distanceProcessor.processBlock(buffer, actualDistance, panning, env);
         
     } catch (const std::exception& e) {
         juce::Logger::writeToLog("Exception in processBlock: " + juce::String(e.what()));
@@ -280,7 +281,7 @@ void SOFARAudioProcessor::setStateInformation (const void* data, int sizeInBytes
             if (newState.hasProperty("roomType"))
             {
                 int roomType = newState.getProperty("roomType", 0);
-                setRoomType(juce::jlimit(0, 4, roomType)); // Validate range (5 room types: 0-4)
+                setRoomType(juce::jlimit(0, DistanceProcessor::numEnvironments - 1, roomType));
             }
         }
         
@@ -295,7 +296,8 @@ void SOFARAudioProcessor::setStateInformation (const void* data, int sizeInBytes
 // Optimized room type management
 void SOFARAudioProcessor::setRoomType(int roomType)
 {
-    juce::ignoreUnused(roomType);
+    currentRoomType = juce::jlimit(0, DistanceProcessor::numEnvironments - 1, roomType);
+    distanceProcessor.setEnvironmentType (static_cast<DistanceProcessor::Environment>(currentRoomType));
 }
 
 int SOFARAudioProcessor::getCurrentRoomType() const


### PR DESCRIPTION
## Summary
- Replace stubbed early-reflection generator with a first-order model using a preallocated buffer
- Load HRIRs via a minimal spherical head model and expose sample-rate aware API
- Add selectable room environments with parameter updates and optimized HRTF mixing

## Testing
- `./build.sh` *(fails: cd: JUCE/extras/Projucer/Builds/MacOSX/: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895a1b270d8832cbe2ba60472768cc3